### PR TITLE
Add timeseries example and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # prosight-new
+
+This repository contains time series data and an example forecasting script `timeseries.py`. The script uses [Darts](https://github.com/unit8co/darts) to train an N-BEATS model on the provided `prolabs_gmv_2020.csv` dataset.
+
+Install dependencies from `requirements.txt` and run the script:
+
+```bash
+pip install -r requirements.txt
+python timeseries.py
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pandas
+darts
+pytorch-lightning
+numpy
+matplotlib

--- a/timeseries.py
+++ b/timeseries.py
@@ -1,0 +1,36 @@
+import pandas as pd
+from darts import TimeSeries
+from darts.models import NBEATSModel
+from darts.metrics import mape
+import matplotlib.pyplot as plt
+
+
+def main():
+    # Load dataset
+    df = pd.read_csv("prolabs_gmv_2020.csv", parse_dates=["date"])
+
+    # Create a TimeSeries using the completed GMV column
+    series = TimeSeries.from_dataframe(df, time_col="date", value_cols="completed_gmv")
+
+    # Split into training and validation sets
+    train, val = series[:-30], series[-30:]
+
+    # Initialize and train the model
+    model = NBEATSModel(input_chunk_length=20, output_chunk_length=10, n_epochs=50, random_state=0)
+    model.fit(train)
+
+    # Predict the next 30 time steps
+    forecast = model.predict(n=30)
+
+    # Evaluate accuracy
+    print("MAPE:", mape(val, forecast))
+
+    # Plot actual vs forecast
+    series.plot(label="actual")
+    forecast.plot(label="forecast")
+    plt.legend()
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add an example `timeseries.py` using the Darts library and provided dataset
- specify Python package requirements
- expand README with instructions for running the example

## Testing
- `python3 -m py_compile timeseries.py`


------
https://chatgpt.com/codex/tasks/task_e_683fb97825f88333b8314002c3807539